### PR TITLE
Fixed order of exception list tuples.

### DIFF
--- a/Maltego.py
+++ b/Maltego.py
@@ -169,7 +169,7 @@ class MaltegoTransform(object):
         r+= "<Exceptions>"
         
         for i in range(len(self.exceptions)):
-            code, ex = self.exceptions[i]
+            ex, code = self.exceptions[i]
             r+= "<Exception code='%s'>%s</Exception>" % (code, str(ex))
         r+= "</Exceptions>" 
         r+= "</MaltegoTransformExceptionMessage>"


### PR DESCRIPTION
The exception list tuples as appended within addException are (exceptionString, code).  The throwException iterator is using (code, ex) which results in incorrect error display within client UI.